### PR TITLE
Adjust folder structure, add prompts

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -6,15 +6,15 @@ const handlers = require('../handlers');
 const prompt = require('../helpers/prompt');
 
 module.exports = async (name, type) => {
-
+  // Prompt for name if not provided
   if (!name) name = await prompt('What is the name of your project?');
 
+  // Prompt for project type if not provided or invalid, allow selection from supported handlers
   if (!type) type = await prompt('Which type of project would you like to create?', keys(handlers));
-
   if (!handlers[type]) type = await prompt('Invalid project type specific, please select from list below:', keys(handlers));
 
+  // Exit out if git not found
   if (!shell.which('git')) return console.log(colors.red('you must have git installed'));
 
   handlers[type](name);
-
 };

--- a/commands/create.js
+++ b/commands/create.js
@@ -1,62 +1,20 @@
 const colors = require('colors');
 const shell = require('shelljs');
-const replace = require('replace-in-file');
+const { keys } = require('lodash');
 
-const config = require('../config');
+const handlers = require('../handlers');
+const prompt = require('../helpers/prompt');
 
-module.exports = (name, type) => {
-  if (!name) return console.log(colors.red('you must specify a project name'));
-  if (!type) return console.log(colors.red('you must specify a project type'));
+module.exports = async (name, type) => {
+
+  if (!name) name = await prompt('What is the name of your project?');
+
+  if (!type) type = await prompt('Which type of project would you like to create?', keys(handlers));
+
+  if (!handlers[type]) type = await prompt('Invalid project type specific, please select from list below:', keys(handlers));
+
   if (!shell.which('git')) return console.log(colors.red('you must have git installed'));
-  switch(type) {
-    case 'api':
-      createAPI(name);
-      break;
-    case 'react':
-      createReact(name);
-      break;
-    case 'react-native':
-      createReactNative(name);
-      break;
-    case 'wordpress':
-      createWordPress(name);
-      break;
-    default:
-      console.log(colors.red('you must specify a valid project type'));
-  }
+
+  handlers[type](name);
+
 };
-
-createAPI = (name) => {
-  console.log('creating api...');
-  shell.exec(`git clone ${config.api_repo} ${name}`);
-  console.log(colors.green('success!'));
-};
-
-createReact = (name) => {
-  console.log('creating react...');
-};
-
-createReactNative = (name) => {
-  console.log('creating react-native...');
-};
-
-createWordPress = (name) => {
-  console.log('creating wordpress...');
-};
-
-/*
-
-
-const options = {
-  files: ['directory/!**!/!*.js'],
-  from: /{{app-name}}/g,
-  to: 'Rich',
-};
-
-replace(options)
-  .then(changedFiles => {
-    console.log('Modified files:', changedFiles.join(', '));
-  })
-  .catch(error => {
-    console.error('Error occurred:', error);
-  });*/

--- a/handlers/api.js
+++ b/handlers/api.js
@@ -1,0 +1,28 @@
+const colors = require('colors');
+const shell = require('shelljs');
+
+const config = require('../config');
+
+module.exports = (name) => {
+  console.log('creating api...');
+  shell.exec(`git clone ${config.api_repo} ${name}`);
+  console.log(colors.green('success!'));
+};
+
+
+/*
+
+
+const options = {
+  files: ['directory/!**!/!*.js'],
+  from: /{{app-name}}/g,
+  to: 'Rich',
+};
+
+replace(options)
+  .then(changedFiles => {
+    console.log('Modified files:', changedFiles.join(', '));
+  })
+  .catch(error => {
+    console.error('Error occurred:', error);
+  });*/

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  api: require('./api'),
+  wordpress: require('./wordpress'),
+  react: require('./react'),
+  'react-native': require('./react-native'),
+};

--- a/handlers/react-native.js
+++ b/handlers/react-native.js
@@ -1,0 +1,8 @@
+const colors = require('colors');
+const shell = require('shelljs');
+
+const config = require('../config');
+
+module.exports = (name) => {
+  console.log('creating react-native...');
+};

--- a/handlers/react.js
+++ b/handlers/react.js
@@ -1,0 +1,8 @@
+const colors = require('colors');
+const shell = require('shelljs');
+
+const config = require('../config');
+
+module.exports = (name) => {
+  console.log('creating react...');
+};

--- a/handlers/wordpress.js
+++ b/handlers/wordpress.js
@@ -1,0 +1,8 @@
+const colors = require('colors');
+const shell = require('shelljs');
+
+const config = require('../config');
+
+module.exports = (name) => {
+  console.log('creating wordpress...');
+};

--- a/helpers/prompt.js
+++ b/helpers/prompt.js
@@ -1,0 +1,29 @@
+const inquirer = require('inquirer');
+const { get, uniqueId } = require('lodash/fp');
+
+/**
+ * Simple async wrapper for inquirer, to prompt user
+ * @async
+ * @param {string} question - Question displayed to user
+ * @param {string[]} [choices=[]] - Predefined answers (optional)
+ * @return {Promise.<string>} - Answer entered or selected by user
+ *
+ * @example
+ * // Displays question, allows freeform entry
+ * prompt('What is your name');
+ * @example
+ * // Provides three options for user to select from
+ * prompt('What is your favorite color?', ['red', 'white', 'blue']);
+ * @example
+ * // Use with `await` for streamlines inquiries
+ * if (!name) name = await prompt('What is the name of your project?');
+ */
+module.exports = (question, choices = []) => {
+  const questionId = uniqueId('prompt_');
+  return inquirer.prompt({
+    type: choices.length ? 'list' : 'input',
+    name: questionId,
+    message: question,
+    choices,
+  }).then(get(questionId));
+};

--- a/index.js
+++ b/index.js
@@ -16,5 +16,6 @@ program
     commands.create(name, options.type);
   });
 
-
 program.parse(process.argv);
+
+if (!program.args.length) program.help();

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "colors": "^1.1.2",
     "commander": "^2.11.0",
+    "inquirer": "^3.3.0",
+    "lodash": "^4.17.4",
     "replace-in-file": "^3.0.0-beta.2",
     "shelljs": "^0.7.8"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -35,13 +39,23 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -111,6 +125,20 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+external-editor@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.5.tgz#52c249a3981b9ba187c7cacf5beb50bf1d91a6bc"
+  dependencies:
+    iconv-lite "^0.4.17"
+    jschardet "^1.4.2"
+    tmp "^0.0.33"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 find-up@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -152,6 +180,10 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
+iconv-lite@^0.4.17:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -162,6 +194,25 @@ inflight@^1.0.4:
 inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inquirer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
 
 interpret@^1.0.0:
   version "1.0.4"
@@ -191,6 +242,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -198,6 +253,10 @@ is-stream@^1.1.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
+jschardet@^1.4.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -221,6 +280,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -243,6 +306,10 @@ minimatch@^3.0.4:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -269,6 +336,12 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 os-locale@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
@@ -276,6 +349,10 @@ os-locale@^2.0.0:
     execa "^0.7.0"
     lcid "^1.0.0"
     mem "^1.1.0"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -370,6 +447,29 @@ resolve@^1.1.6:
   dependencies:
     path-parse "^1.0.5"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
 "semver@2 || 3 || 4 || 5":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -396,7 +496,7 @@ shelljs@^0.7.8:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-signal-exit@^3.0.0:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -422,7 +522,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -454,6 +554,16 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This started with just the basic want of adding prompts to allow user selection from predefined choices. Along the way, it seemed that moving to an object structure for specifying project type handlers would reduce on validation needs (previously solved by the switch/case) and promote some separation of concerns.

Considering how simple the actual project type handlers may be, this may end up looking a bit like a preemptive optimization but I like the cleanliness of using the handlers object for validation of project type and it keeps the create command's function clean.

GIF of changes in action:
![cli](https://user-images.githubusercontent.com/1479206/32048097-3d65ebc6-ba16-11e7-936c-1f6ca2d46a31.gif)
